### PR TITLE
Add ApplicationType tag

### DIFF
--- a/groups/cics-infrastructure/locals.tf
+++ b/groups/cics-infrastructure/locals.tf
@@ -28,6 +28,7 @@ locals {
   default_tags = {
     Terraform   = "true"
     Application = upper(var.application)
+    ApplicationType = upper(var.application_type)
     Region      = var.aws_region
     Account     = var.aws_account
   }

--- a/groups/cics-infrastructure/variables.tf
+++ b/groups/cics-infrastructure/variables.tf
@@ -52,6 +52,12 @@ variable "application" {
   description = "The name of the application"
 }
 
+variable "application_type" {
+  type        = string
+  default     = "cics"
+  description = "The parent name of the application"
+}
+
 variable "environment" {
   type        = string
   description = "The name of the environment"


### PR DESCRIPTION
This adds a new tag, ApplicationType, which will be used by the bootstrap process of the Docker AMI to identify the name of the NFS share that is used by the WebLogic tier.

Currently, the Application tag is used for this purpose, but there will be a new version of the AMI that will use this tag instead, in order to make it more flexible and cater for CHIPS. 