### PR TITLE
Increase live and staging CICS instance sizes as low memory reported

### DIFF
--- a/groups/cics-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cics-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -13,7 +13,7 @@ environment = "live"
 
 # ASG settings
 cics_asg_count = 2
-cics_instance_size = "t3.medium"
+cics_instance_size = "t3.large"
 
 # CVO NFS Mounts
 nfs_server = "192.168.255.35"

--- a/groups/cics-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cics-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -13,7 +13,7 @@ environment = "staging"
 
 # ASG settings
 cics_asg_count = 1
-cics_instance_size = "t3.medium"
+cics_instance_size = "t3.large"
 
 # CVO NFS Mounts
 nfs_server = "192.168.255.19"


### PR DESCRIPTION
There is low memory on the live cics EC2 instances, so we are increasing the size from t3.medium to t3.large.  This will double the RAM without increasing the WebLogic licence count.

At a later point we will probably also remove the cics2 instance from live and just run with one there, to free a WebLogic licence and reduce costs. That will be raised separately.