### PR TITLE
Add ingress to ALB on port 443 for chips-control instances

### DIFF
--- a/groups/cics-infrastructure/alb.tf
+++ b/groups/cics-infrastructure/alb.tf
@@ -8,6 +8,17 @@ module "cics_internal_alb_security_group" {
 
   ingress_cidr_blocks = local.admin_cidrs
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+
+  ingress_with_source_security_group_id = [
+    {
+      from_port                = 443
+      to_port                  = 443
+      protocol                 = "tcp"
+      description              = "HTTPS from chips-control"
+      source_security_group_id = data.aws_security_group.chips_control.id
+    }
+  ]
+
   egress_rules        = ["all-all"]
 }
 

--- a/groups/cics-infrastructure/data.tf
+++ b/groups/cics-infrastructure/data.tf
@@ -21,6 +21,13 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
+data "aws_security_group" "chips_control" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-control-asg-001-*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true


### PR DESCRIPTION
Allow access from Rundeck on chips-control instance to enable service checks to run against the CICS application.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1499