### PR TITLE
Add CIS scanning policy and use EBS encryption, IMDSv2, gp3 and NFS config in vault

### DIFF
--- a/groups/cics-infrastructure/asg.tf
+++ b/groups/cics-infrastructure/asg.tf
@@ -81,11 +81,11 @@ resource "aws_autoscaling_schedule" "cics-schedule-start-cics2" {
 
 # ASG Module for cics1
 module "cics1_asg" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/terraform-aws-autoscaling?ref=tags/1.0.36"
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.244"
 
   name = "${var.application}1"
-  # Launch configuration
-  lc_name       = "${var.application}1-launchconfig"
+  # Launch template configuration
+  lt_name       = "${var.application}1-launchtemplate"
   image_id      = data.aws_ami.cics.id
   instance_type = var.cics_instance_size
   security_groups = [
@@ -94,11 +94,16 @@ module "cics1_asg" {
   ]
   root_block_device = [
     {
-      volume_size = "40"
-      volume_type = "gp2"
+      volume_size = var.instance_root_volume_size
       encrypted   = true
-      iops        = 0
-    },
+    }
+  ]
+  block_device_mappings = [
+    {
+      device_name = "/dev/xvdb"
+      encrypted   = true
+      volume_size = var.instance_swap_volume_size
+    }
   ]
   # Auto scaling group
   asg_name                       = "${var.application}1-asg"
@@ -122,6 +127,7 @@ module "cics1_asg" {
   ]
   iam_instance_profile = module.cics_profile.aws_iam_instance_profile.name
   user_data_base64     = data.template_cloudinit_config.cics_userdata_config.rendered
+  enforce_imdsv2       = true
 
   tags_as_map = merge(
     local.default_tags,
@@ -134,12 +140,12 @@ module "cics1_asg" {
 
 # ASG Module for cics2
 module "cics2_asg" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/terraform-aws-autoscaling?ref=tags/1.0.36"
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.244"
 
   count = var.cics_asg_count > 1 ? 1 : 0
   name  = "${var.application}2"
-  # Launch configuration
-  lc_name       = "${var.application}2-launchconfig"
+  # Launch template configuration
+  lt_name       = "${var.application}2-launchtemplate"
   image_id      = data.aws_ami.cics.id
   instance_type = var.cics_instance_size
   security_groups = [
@@ -148,11 +154,16 @@ module "cics2_asg" {
   ]
   root_block_device = [
     {
-      volume_size = "40"
-      volume_type = "gp2"
+      volume_size = var.instance_root_volume_size
       encrypted   = true
-      iops        = 0
-    },
+    }
+  ]
+  block_device_mappings = [
+    {
+      device_name = "/dev/xvdb"
+      encrypted   = true
+      volume_size = var.instance_swap_volume_size
+    }
   ]
   # Auto scaling group
   asg_name                       = "${var.application}2-asg"
@@ -176,6 +187,7 @@ module "cics2_asg" {
   ]
   iam_instance_profile = module.cics_profile.aws_iam_instance_profile.name
   user_data_base64     = data.template_cloudinit_config.cics_userdata_config.rendered
+  enforce_imdsv2       = true
 
   tags_as_map = merge(
     local.default_tags,

--- a/groups/cics-infrastructure/asg.tf
+++ b/groups/cics-infrastructure/asg.tf
@@ -117,9 +117,7 @@ module "cics1_asg" {
   force_delete                   = true
   enable_instance_refresh        = true
   refresh_min_healthy_percentage = 50
-  refresh_triggers               = ["launch_configuration"]
   key_name                       = aws_key_pair.cics_keypair.key_name
-  termination_policies           = ["OldestLaunchConfiguration"]
   target_group_arns = [
     aws_lb_target_group.cics_app[0].arn,
     aws_lb_target_group.cics_app[1].arn,

--- a/groups/cics-infrastructure/data.tf
+++ b/groups/cics-infrastructure/data.tf
@@ -45,6 +45,10 @@ data "vault_generic_secret" "cics_ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/ec2"
 }
 
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/app/nfs_mounts"
+}
+
 data "aws_acm_certificate" "acm_cert" {
   domain = var.domain_name
 }

--- a/groups/cics-infrastructure/iam.tf
+++ b/groups/cics-infrastructure/iam.tf
@@ -59,3 +59,8 @@ module "cics_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.cics_profile.aws_iam_role.name
+}

--- a/groups/cics-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/cics-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -15,17 +15,6 @@ environment = "development"
 cics_asg_count = 1
 cics_instance_size = "t3.medium"
 
-# CVO NFS Mounts
-nfs_server = "10.104.9.145"
-nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  cics = {
-    local_mount_point = "cics"
-  }
-}
-
-
-
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs
 # 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )

--- a/groups/cics-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/cics-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -15,16 +15,6 @@ environment = "live"
 cics_asg_count = 2
 cics_instance_size = "t3.large"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.35"
-nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  cics = {
-    local_mount_point = "cics"
-  }
-}
-
-
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs
 # 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )

--- a/groups/cics-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/cics-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -15,16 +15,6 @@ environment = "staging"
 cics_asg_count = 1
 cics_instance_size = "t3.large"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.19"
-nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  cics = {
-    local_mount_point = "cics"
-  }
-}
-
-
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs
 # 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )

--- a/groups/cics-infrastructure/templates/cics_user_data.tpl
+++ b/groups/cics-infrastructure/templates/cics_user_data.tpl
@@ -3,14 +3,10 @@
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 #Get application instance identifier from tags in AWS metadata service
-EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_INSTANCE_ID=$( ec2-metadata -i | awk '{print $2}' )
+AVAILABILITY_ZONE=$( ec2-metadata -z | awk '{print $2}' )
 EC2_REGION=$${AVAILABILITY_ZONE::-1}
 APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=$EC2_INSTANCE_ID" "Name=key,Values=app-instance-name"  --region $EC2_REGION | jq -r '.Tags[]//[]|select(.Key=="app-instance-name")|.Value' )
-
-#Update Nagios registration script with relevant template
-cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
-REPLACE=CICs_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
 
 #Template application identifier into deployment playbook inputs
 echo '${ANSIBLE_INPUTS}' | jq --arg APP_INSTANCE_NAME "$APP_INSTANCE_NAME"  'walk(if type == "object" and has("file_path") then .file_path |= sub("APPINSTANCENAME"; $APP_INSTANCE_NAME) else . end)' > /root/ansible_inputs.json
@@ -18,10 +14,5 @@ echo '${ANSIBLE_INPUTS}' | jq --arg APP_INSTANCE_NAME "$APP_INSTANCE_NAME"  'wal
 #Run Ansible playbook for server setup using provided inputs
 /usr/local/bin/ansible-playbook /root/deployment.yml -e '@/root/ansible_inputs.json'
 
+#Run bootstrap script to download config from S3 and start Docker containers
 su -l ec2-user bootstrap
-
-# Allow permissive selinux permissions to nrpe
-semanage permissive -a nrpe_t
-semanage permissive -a systemd_logind_t
-
-mv /usr/local/bin/check_docker /usr/lib64/nagios/plugins/check_docker

--- a/groups/cics-infrastructure/variables.tf
+++ b/groups/cics-infrastructure/variables.tf
@@ -101,6 +101,18 @@ variable "cics_ami_name" {
   description = "Name of the AMI to use in the Auto Scaling configuration for CICs"
 }
 
+variable "instance_root_volume_size" {
+  type        = number
+  default     = 40
+  description = "Size of root volume attached to instances"
+}
+
+variable "instance_swap_volume_size" {
+  type        = number
+  default     = 5
+  description = "Size of swap volume attached to instances"
+}
+
 # ------------------------------------------------------------------------------
 # CIC ALB Variables
 # ------------------------------------------------------------------------------
@@ -135,36 +147,10 @@ variable "domain_name" {
   description = "Domain Name for ACM Certificate"
 }
 
-# ------------------------------------------------------------------------------
-# NFS Mount Variables
-# ------------------------------------------------------------------------------
-# See Ansible role for full documentation on NFS arguements:
-#      https://github.com/companieshouse/ansible-collections/tree/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts
-variable "nfs_server" {
-  type        = string
-  description = "The name or IP of the environment specific NFS server"
-  default     = null
-}
-
 variable "nfs_mount_destination_parent_dir" {
   type        = string
   description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
-  default     = "/mnt"
-}
-
-variable "nfs_mounts" {
-  type        = map(any)
-  description = "A map of objects which contains mount details for each mount path required."
-  # Example: 
-  #   nfs_share_name = {                  # The name of the NFS Share from the NFS Server
-  #     local_mount_point = "folder",     # The name of the local folder to mount to under the parent directory, if omitted the share name is used.
-  #     mount_options = [                 # Traditional mount options as documented for any NFS Share mounts
-  #       "rw",
-  #       "wsize=8192"
-  #     ]
-  #   }
-  # }
-  #
+  default     = "/mnt/nfs"
 }
 
 variable "default_log_group_retention_in_days" {


### PR DESCRIPTION
Refreshes the CICs terraform to:

- Add a policy to allow CIS scanning from AWS Inspector
- Move the NFS config (such as server address) from terraform into vault
- Use a launch template and enforce use of IMDSv2
- Use the ami default of gp3 volumes, enable encryption for EBS swap volume
- Removes nagios config as that is no longer required

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2793